### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 > [!IMPORTANT]  
 > The code in this repository and its dependencies are still under audit. It is not yet recommended for production use.
 
+# Getting Started
+
+The smart wallet package is managed using [Foundry](https://book.getfoundry.sh) the smart contract development toolchain.
+
+**Install Modules**
+```bash
+forge install
+```
+
+**Run Tests**
+```bash
+forge test
+```
+
+**Run Build**
+```bash
+forge build
+```
+
+Solidity `0.8.23` is used to compile and test the smart contracts. 
+
 # Smart Wallet
 
 This repository contains code for a new, [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) compliant smart contract wallet from Coinbase. 
@@ -86,13 +107,6 @@ Today, allowed are
 | Network   | CoinbaseSmartWalletFactory Address                        |
 |-----------|-----------------------------------------|
 | Base Sepolia | [0xeD4EAeBDBBA52DBB37259a2b75AbB87abF3a19E8](https://sepolia.basescan.org/address/0xeD4EAeBDBBA52DBB37259a2b75AbB87abF3a19E8) |
-
-
-## Developing 
-After cloning the repo, run the tests using Forge, from [Foundry](https://github.com/foundry-rs/foundry?tab=readme-ov-file)
-```bash
-forge test
-```
 
 ## Influences
 Much of the code in this repository started from Solady's [ERC4337](https://github.com/Vectorized/solady/blob/main/src/accounts/ERC4337.sol) implementation. We were also influenced by [DaimoAccount](https://github.com/daimo-eth/daimo/blob/master/packages/contract/src/DaimoAccount.sol), which pioneered using passkey signers on ERC-4337 accounts, and [LightAccount](https://github.com/alchemyplatform/light-account).


### PR DESCRIPTION
I know most smart contract developers default to Foundry these days, so for the most part it doesn't need to be introduced, but think it's always nice to include a "Getting Started" section at the top of a README that quickly introduces the framework and basic commands.

The PR adds a basic "Getting Started" section to the README with a link to Foundry and common commands.