### PR TITLE
Improve test coverage

### DIFF
--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -171,7 +171,7 @@ contract CoinbaseSmartWallet is MultiOwnable, UUPSUpgradeable, Receiver, ERC1271
     ///
     /// @dev Can only be called by the Entrypoint.
     /// @dev Reverts if the given call is not authorized to skip the chain ID validtion.
-    /// @dev `validateUserOp()` will recompute the `userOpHash` without the chain ID befor validatin
+    /// @dev `validateUserOp()` will recompute the `userOpHash` without the chain ID before validating
     ///      it if the `UserOperation` aims at executing this function. This allows certain operations
     ///      to be replayed for all accounts sharing the same address across chains. E.g. This may be
     ///      useful for syncing owner changes.

--- a/test/CoinbaseSmartWallet/ExecuteWithoutChainIdValidation.t.sol
+++ b/test/CoinbaseSmartWallet/ExecuteWithoutChainIdValidation.t.sol
@@ -35,16 +35,13 @@ contract TestExecuteWithoutChainIdValidation is SmartWalletTestBase {
     }
 
     function test_cannotCallExec() public {
-        userOpCalldata = abi.encodeWithSelector(
-            CoinbaseSmartWallet.executeWithoutChainIdValidation.selector,
-            abi.encodeWithSelector(CoinbaseSmartWallet.execute.selector, "")
-        );
-        UserOperation memory userOp = _getUserOpWithSignature();
-        vm.expectEmit(true, true, true, true);
-        emit IEntryPoint.UserOperationEvent(
-            entryPoint.getUserOpHash(userOp), userOp.sender, address(0), userOp.nonce, false, 0, 48005
-        );
-        _sendUserOperation(userOp);
+        bytes memory restrictedSelectorCalldata = abi.encodeWithSelector(CoinbaseSmartWallet.execute.selector, "");
+        vm.prank(address(entryPoint));
+        vm.expectRevert(abi.encodeWithSelector(
+                CoinbaseSmartWallet.SelectorNotAllowed.selector, 
+                CoinbaseSmartWallet.execute.selector
+        ));
+        account.executeWithoutChainIdValidation(restrictedSelectorCalldata);
     }
 
     function _sign(UserOperation memory userOp) internal view override returns (bytes memory signature) {


### PR DESCRIPTION
Our test coverage is lacking for some contracts/methods. This PR addresses this and attempts to get our coverage to 100% for all critical source files. 

For reference, our initial `foundry coverage` report:

```
| File                                             | % Lines          | % Statements     | % Branches     | % Funcs         |
|--------------------------------------------------|------------------|------------------|----------------|-----------------|
| script/DeployERC4337Factory.s.sol                | 0.00% (0/8)      | 0.00% (0/12)     | 100.00% (0/0)  | 0.00% (0/2)     |
| src/CoinbaseSmartWallet.sol                      | 95.65% (44/46)   | 96.92% (63/65)   | 90.91% (20/22) | 92.31% (12/13)  |
| src/CoinbaseSmartWalletFactory.sol               | 100.00% (10/10)  | 100.00% (10/10)  | 75.00% (3/4)   | 75.00% (3/4)    |
| src/ERC1271.sol                                  | 85.71% (12/14)   | 89.47% (17/19)   | 100.00% (2/2)  | 100.00% (6/6)   |
| src/MultiOwnable.sol                             | 100.00% (27/27)  | 100.00% (38/38)  | 80.00% (8/10)  | 100.00% (13/13) |
| src/utils/ERC1271InputGenerator.sol              | 0.00% (0/9)      | 0.00% (0/14)     | 0.00% (0/6)    | 0.00% (0/1)     |
| test/CoinbaseSmartWallet/SmartWalletTestBase.sol | 0.00% (0/16)     | 0.00% (0/18)     | 0.00% (0/1)    | 0.00% (0/6)     |
| test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol  | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)  | 50.00% (1/2)    |
| test/MultiOwnable/MultiOwnableTestBase.t.sol     | 0.00% (0/3)      | 0.00% (0/3)      | 100.00% (0/0)  | 0.00% (0/1)     |
| test/mocks/MockCoinbaseSmartWallet.sol           | 50.00% (1/2)     | 66.67% (2/3)     | 100.00% (0/0)  | 50.00% (1/2)    |
| test/mocks/MockEntryPoint.sol                    | 40.00% (2/5)     | 33.33% (2/6)     | 0.00% (0/2)    | 33.33% (1/3)    |
| test/mocks/MockMultiOwnable.sol                  | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)  | 100.00% (1/1)   |
| test/mocks/MockTarget.sol                        | 80.00% (4/5)     | 100.00% (4/4)    | 0.00% (0/1)    | 66.67% (2/3)    |
| Total                                            | 69.39% (102/147) | 71.13% (138/194) | 68.75% (33/48) | 70.18% (40/57)  |
```