### PR TITLE
Get CoinbaseSmartWallet to 100% test coverage 

### DIFF
--- a/test/CoinbaseSmartWallet/Implementation.t.sol
+++ b/test/CoinbaseSmartWallet/Implementation.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {CoinbaseSmartWalletFactory} from "../../src/CoinbaseSmartWalletFactory.sol";
+import {CoinbaseSmartWallet} from "../../src/CoinbaseSmartWallet.sol";
+
+import "./SmartWalletTestBase.sol";
+
+contract TestImplementation is SmartWalletTestBase {
+    address implementation = address(new CoinbaseSmartWallet());
+
+    function setUp() public override {
+        super.setUp();
+        CoinbaseSmartWalletFactory factory = new CoinbaseSmartWalletFactory(implementation);
+        account = factory.createAccount(owners, 1);
+    }
+
+    function testImplementation() public {
+        address addr = account.implementation();
+        assertEq(addr, implementation);
+    }
+}

--- a/test/CoinbaseSmartWallet/IsValidSignature.t.sol
+++ b/test/CoinbaseSmartWallet/IsValidSignature.t.sol
@@ -173,9 +173,10 @@ contract TestIsValidSignature is SmartWalletTestBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, toSign);
         bytes memory signature = abi.encodePacked(r, s, v);
         bytes32 invalidAddress = bytes32(uint256(type(uint160).max) + 1);
-        bytes32 slotOfOwnerAtIndex = 0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f01;
-        bytes32 slot = bytes32(uint256(keccak256(abi.encodePacked(keccak256(abi.encode(0, slotOfOwnerAtIndex))))));
-        vm.store(address(account), slot, invalidAddress);
+        bytes32 slot_ownerAtIndex = 0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f01; // MUTLI_OWNABLE_STORAGE_LOCATION + 1
+        bytes32 slot_ownerAtIndex_zeroIndex =
+            bytes32(uint256(keccak256(abi.encodePacked(keccak256(abi.encode(0, slot_ownerAtIndex))))));
+        vm.store(address(account), slot_ownerAtIndex_zeroIndex, invalidAddress);
         vm.expectRevert(
             abi.encodeWithSelector(MultiOwnable.InvalidEthereumAddressOwner.selector, abi.encode(invalidAddress))
         );

--- a/test/CoinbaseSmartWallet/IsValidSignature.t.sol
+++ b/test/CoinbaseSmartWallet/IsValidSignature.t.sol
@@ -165,4 +165,22 @@ contract TestIsValidSignature is SmartWalletTestBase {
         vm.expectRevert();
         account.isValidSignature(hash, abi.encode(CoinbaseSmartWallet.SignatureWrapper(1, signature)));
     }
+
+    // @dev this case should not be possible, but we need to explicitly test the revert case 
+    function testRevertsIfOwnerIsInvalidEthereumAddress() public {
+        bytes32 hash = 0x15fa6f8c855db1dccbb8a42eef3a7b83f11d29758e84aed37312527165d5eec5;
+        bytes32 toSign = account.replaySafeHash(hash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, toSign);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        bytes32 invalidAddress = bytes32(uint256(type(uint160).max)+1);
+        bytes32 slotOfOwnerAtIndex = 0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f01;
+        bytes32 slot = bytes32(uint256(keccak256(abi.encodePacked(keccak256(abi.encode(0, slotOfOwnerAtIndex))))));
+        vm.store(address(account), slot, invalidAddress);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MultiOwnable.InvalidEthereumAddressOwner.selector,
+                abi.encode(invalidAddress))
+            );
+        account.isValidSignature(hash, abi.encode(CoinbaseSmartWallet.SignatureWrapper(0, signature)));
+    }
 }

--- a/test/CoinbaseSmartWallet/IsValidSignature.t.sol
+++ b/test/CoinbaseSmartWallet/IsValidSignature.t.sol
@@ -166,21 +166,19 @@ contract TestIsValidSignature is SmartWalletTestBase {
         account.isValidSignature(hash, abi.encode(CoinbaseSmartWallet.SignatureWrapper(1, signature)));
     }
 
-    // @dev this case should not be possible, but we need to explicitly test the revert case 
+    // @dev this case should not be possible, but we need to explicitly test the revert case
     function testRevertsIfOwnerIsInvalidEthereumAddress() public {
         bytes32 hash = 0x15fa6f8c855db1dccbb8a42eef3a7b83f11d29758e84aed37312527165d5eec5;
         bytes32 toSign = account.replaySafeHash(hash);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, toSign);
         bytes memory signature = abi.encodePacked(r, s, v);
-        bytes32 invalidAddress = bytes32(uint256(type(uint160).max)+1);
+        bytes32 invalidAddress = bytes32(uint256(type(uint160).max) + 1);
         bytes32 slotOfOwnerAtIndex = 0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f01;
         bytes32 slot = bytes32(uint256(keccak256(abi.encodePacked(keccak256(abi.encode(0, slotOfOwnerAtIndex))))));
         vm.store(address(account), slot, invalidAddress);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                MultiOwnable.InvalidEthereumAddressOwner.selector,
-                abi.encode(invalidAddress))
-            );
+            abi.encodeWithSelector(MultiOwnable.InvalidEthereumAddressOwner.selector, abi.encode(invalidAddress))
+        );
         account.isValidSignature(hash, abi.encode(CoinbaseSmartWallet.SignatureWrapper(0, signature)));
     }
 }

--- a/test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol
+++ b/test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol
@@ -20,10 +20,10 @@ contract TestUpgradeToAndCall is SmartWalletTestBase {
         account.upgradeToAndCall(newImplementation, abi.encodeWithSignature("dummy()"));
         Dummy(address(account)).dummy();
     }
-    
+
     function testUpgradeToAndCallWithNonOwner() public {
         vm.startPrank(address(1));
-        vm.expectRevert(MultiOwnable.Unauthorized.selector);  
+        vm.expectRevert(MultiOwnable.Unauthorized.selector);
         account.upgradeToAndCall(newImplementation, abi.encodeWithSignature("dummy()"));
     }
 }

--- a/test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol
+++ b/test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol
@@ -2,22 +2,29 @@
 pragma solidity ^0.8.0;
 
 import {CoinbaseSmartWalletFactory} from "../../src/CoinbaseSmartWalletFactory.sol";
+import {CoinbaseSmartWallet} from "../../src/CoinbaseSmartWallet.sol";
 
 import "./SmartWalletTestBase.sol";
 
 contract TestUpgradeToAndCall is SmartWalletTestBase {
-    address newImplementation = address(new Dummy());
+    address newImplementation = address(new CoinbaseSmartWallet());
 
     function setUp() public override {
         super.setUp();
         CoinbaseSmartWalletFactory factory = new CoinbaseSmartWalletFactory(address(new CoinbaseSmartWallet()));
         account = factory.createAccount(owners, 1);
-        vm.startPrank(signer);
     }
 
     function testUpgradeToAndCall() public {
+        vm.startPrank(signer);
         account.upgradeToAndCall(newImplementation, abi.encodeWithSignature("dummy()"));
         Dummy(address(account)).dummy();
+    }
+    
+    function testUpgradeToAndCallWithNonOwner() public {
+        vm.startPrank(address(1));
+        vm.expectRevert(MultiOwnable.Unauthorized.selector);  
+        account.upgradeToAndCall(newImplementation, abi.encodeWithSignature("dummy()"));
     }
 }
 

--- a/test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol
+++ b/test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol
@@ -2,29 +2,22 @@
 pragma solidity ^0.8.0;
 
 import {CoinbaseSmartWalletFactory} from "../../src/CoinbaseSmartWalletFactory.sol";
-import {CoinbaseSmartWallet} from "../../src/CoinbaseSmartWallet.sol";
 
 import "./SmartWalletTestBase.sol";
 
 contract TestUpgradeToAndCall is SmartWalletTestBase {
-    address newImplementation = address(new CoinbaseSmartWallet());
+    address newImplementation = address(new Dummy());
 
     function setUp() public override {
         super.setUp();
         CoinbaseSmartWalletFactory factory = new CoinbaseSmartWalletFactory(address(new CoinbaseSmartWallet()));
         account = factory.createAccount(owners, 1);
+        vm.startPrank(signer);
     }
 
     function testUpgradeToAndCall() public {
-        vm.startPrank(signer);
         account.upgradeToAndCall(newImplementation, abi.encodeWithSignature("dummy()"));
         Dummy(address(account)).dummy();
-    }
-
-    function testUpgradeToAndCallWithNonOwner() public {
-        vm.startPrank(address(1));
-        vm.expectRevert(MultiOwnable.Unauthorized.selector);
-        account.upgradeToAndCall(newImplementation, abi.encodeWithSignature("dummy()"));
     }
 }
 


### PR DESCRIPTION
As part of an ongoing effort to achieve 100% coverage for all contracts in this repo...

1. Added a test for a (currently) impossible to reach case wherein an invalid ethereum address is stored as an owner for a smart wallet. This is achieved by directly writing an invalid `owner bytes` into the storage of MultiOwnable before making a call to `isValidSignature`. 
2. Added a test for the `implementation()` method

`foundry coverage` report as of this PR: 
```
| File                                             | % Lines          | % Statements     | % Branches      | % Funcs         |
|--------------------------------------------------|------------------|------------------|-----------------|-----------------|
| script/DeployERC4337Factory.s.sol                | 0.00% (0/8)      | 0.00% (0/12)     | 100.00% (0/0)   | 0.00% (0/2)     |
| src/CoinbaseSmartWallet.sol                      | 100.00% (46/46)  | 100.00% (65/65)  | 100.00% (22/22) | 100.00% (13/13) |
| src/CoinbaseSmartWalletFactory.sol               | 100.00% (10/10)  | 100.00% (10/10)  | 75.00% (3/4)    | 75.00% (3/4)    |
| src/ERC1271.sol                                  | 85.71% (12/14)   | 89.47% (17/19)   | 100.00% (2/2)   | 100.00% (6/6)   |
| src/MultiOwnable.sol                             | 100.00% (27/27)  | 100.00% (38/38)  | 80.00% (8/10)   | 100.00% (13/13) |
| src/utils/ERC1271InputGenerator.sol              | 0.00% (0/9)      | 0.00% (0/14)     | 0.00% (0/6)     | 0.00% (0/1)     |
| test/CoinbaseSmartWallet/SmartWalletTestBase.sol | 0.00% (0/16)     | 0.00% (0/18)     | 0.00% (0/1)     | 0.00% (0/6)     |
| test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol  | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 50.00% (1/2)    |
| test/MultiOwnable/MultiOwnableTestBase.t.sol     | 0.00% (0/3)      | 0.00% (0/3)      | 100.00% (0/0)   | 0.00% (0/1)     |
| test/mocks/MockCoinbaseSmartWallet.sol           | 50.00% (1/2)     | 66.67% (2/3)     | 100.00% (0/0)   | 50.00% (1/2)    |
| test/mocks/MockEntryPoint.sol                    | 40.00% (2/5)     | 33.33% (2/6)     | 0.00% (0/2)     | 33.33% (1/3)    |
| test/mocks/MockMultiOwnable.sol                  | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)   |
| test/mocks/MockTarget.sol                        | 80.00% (4/5)     | 100.00% (4/4)    | 0.00% (0/1)     | 66.67% (2/3)    |
| Total                                            | 70.75% (104/147) | 72.16% (140/194) | 72.92% (35/48)  | 71.93% (41/57)  |
```