### PR TITLE
Get CoinbaseSmartContractFactory and ERC1271 to 100% coverage 

### DIFF
--- a/test/CoinbaseSmartWalletFactory.t.sol
+++ b/test/CoinbaseSmartWalletFactory.t.sol
@@ -34,7 +34,7 @@ contract CoinbaseSmartWalletFactoryTest is Test {
     }
 
     function test_exitIfAccountIsAlreadyInitialized() public {
-        CoinbaseSmartWallet a = factory.createAccount{value: 1e18}(owners, 0);
+        CoinbaseSmartWallet a = factory.createAccount(owners, 0);
         vm.expectCall(address(a), abi.encodeCall(CoinbaseSmartWallet.initialize, (owners)), 0);
         CoinbaseSmartWallet a2 = factory.createAccount(owners, 0);
         assertEq(address(a), address(a2));

--- a/test/CoinbaseSmartWalletFactory.t.sol
+++ b/test/CoinbaseSmartWalletFactory.t.sol
@@ -40,7 +40,7 @@ contract CoinbaseSmartWalletFactoryTest is Test {
         assertEq(address(a), address(a2));
     }
 
-    function testRevertsIfLength32ButLargerThanAddress() public {
+    function test_RevertsIfLength32ButLargerThanAddress() public {
         bytes memory badOwner = abi.encode(uint256(type(uint160).max) + 1);
         owners.push(badOwner);
         vm.expectRevert(abi.encodeWithSelector(MultiOwnable.InvalidEthereumAddressOwner.selector, badOwner));

--- a/test/CoinbaseSmartWalletFactory.t.sol
+++ b/test/CoinbaseSmartWalletFactory.t.sol
@@ -74,8 +74,6 @@ contract CoinbaseSmartWalletFactoryTest is Test {
     function test_initCodeHash() public {
         bytes32 execptedHash = LibClone.initCodeHashERC1967(address(account));
         bytes32 factoryHash = factory.initCodeHash();
-        console2.logBytes32(execptedHash);
-        console2.logBytes32(factoryHash);
         assertEq(factoryHash, execptedHash);
     }
 }

--- a/test/CoinbaseSmartWalletFactory.t.sol
+++ b/test/CoinbaseSmartWalletFactory.t.sol
@@ -32,6 +32,13 @@ contract CoinbaseSmartWalletFactoryTest is Test {
         factory.createAccount{value: 1e18}(owners, 0);
     }
 
+    function test_exitIfAccountIsAlreadyInitialized() public {
+        CoinbaseSmartWallet a = factory.createAccount{value: 1e18}(owners, 0);
+        vm.expectCall(address(a), abi.encodeCall(CoinbaseSmartWallet.initialize, (owners)), 0);
+        CoinbaseSmartWallet a2 = factory.createAccount(owners, 0);
+        assertEq(address(a), address(a2));
+    }
+
     function test_createAccountDeploysToPredeterminedAddress() public {
         address p = factory.getAddress(owners, 0);
         CoinbaseSmartWallet a = factory.createAccount{value: 1e18}(owners, 0);

--- a/test/CoinbaseSmartWalletFactory.t.sol
+++ b/test/CoinbaseSmartWalletFactory.t.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.0;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {CoinbaseSmartWallet} from "../src/CoinbaseSmartWallet.sol";
+import {CoinbaseSmartWallet, MultiOwnable} from "../src/CoinbaseSmartWallet.sol";
 import {CoinbaseSmartWalletFactory} from "../src/CoinbaseSmartWalletFactory.sol";
+import {LibClone} from "solady/utils/LibClone.sol";
 
 contract CoinbaseSmartWalletFactoryTest is Test {
     CoinbaseSmartWalletFactory factory;
@@ -39,6 +40,13 @@ contract CoinbaseSmartWalletFactoryTest is Test {
         assertEq(address(a), address(a2));
     }
 
+    function testRevertsIfLength32ButLargerThanAddress() public {
+        bytes memory badOwner = abi.encode(uint256(type(uint160).max) + 1);
+        owners.push(badOwner);
+        vm.expectRevert(abi.encodeWithSelector(MultiOwnable.InvalidEthereumAddressOwner.selector, badOwner));
+        factory.createAccount{value: 1e18}(owners, 0);
+    }
+
     function test_createAccountDeploysToPredeterminedAddress() public {
         address p = factory.getAddress(owners, 0);
         CoinbaseSmartWallet a = factory.createAccount{value: 1e18}(owners, 0);
@@ -61,5 +69,13 @@ contract CoinbaseSmartWalletFactoryTest is Test {
 
     function test_implementation_returnsExpectedAddress() public {
         assertEq(factory.implementation(), address(account));
+    }
+
+    function test_initCodeHash() public {
+        bytes32 execptedHash = LibClone.initCodeHashERC1967(address(account));
+        bytes32 factoryHash = factory.initCodeHash();
+        console2.logBytes32(execptedHash);
+        console2.logBytes32(factoryHash);
+        assertEq(factoryHash, execptedHash);
     }
 }

--- a/test/ERC1271.t.sol
+++ b/test/ERC1271.t.sol
@@ -21,9 +21,18 @@ contract ERC1271Test is Test {
     }
 
     function test_returnsExpectedDomainHashWhenProxy() public {
-        (, string memory name, string memory version, uint256 chainId, address verifyingContract,,) =
-            account.eip712Domain();
+        (
+            ,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        ) = account.eip712Domain();
         assertEq(verifyingContract, address(account));
+        assertEq(abi.encode(extensions), abi.encode(new uint256[](0)));
+        assertEq(salt, bytes32(0));
         bytes32 expected = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),


### PR DESCRIPTION
As part of an ongoing effort to achieve 100% coverage for all contracts in this repo...

## CoinbaseSmartContractFactory
1. Added a missing test for `initCodeHash()` 
2. Added two new tests to catch missing branch in `createAccount` for cases when the account has already been intitialized and another case wherein the account cannot be initialized because of malformed owner bytes.

## ERC1271
Currently, foundry coverage doesn't like the fact that we return the return-declared `salt` and `extensions`. Adding an explicit check that the return values match the uninitialized args doesn't tick the coverage box. However, in uncommitted changes (shown below), explicitly defining the values of `salt` and `extensions` gets this test to pass with "full coverage". Since explicitly declaring these variables (again) adds ~50 gas, we shouldn't make the change just for the sake of the coverage report. 

```solidity
    function eip712Domain()
        external
        view
        virtual
        returns (
            bytes1 fields,
            string memory name,
            string memory version,
            uint256 chainId,
            address verifyingContract,
            bytes32 salt,
            uint256[] memory extensions
        )
    {
        fields = hex"0f"; // `0b1111`.
        (name, version) = _domainNameAndVersion();
        chainId = block.chainid;
        verifyingContract = address(this);
        // salt = salt; // `bytes32(0)`.
        // extensions = extensions; // `new uint256[](0)`.
        salt = bytes32(0);
        extensions = new uint256[](0); 
    }
```
 
Coverage report as of this PR:
```
| File                                             | % Lines          | % Statements     | % Branches      | % Funcs         |
|--------------------------------------------------|------------------|------------------|-----------------|-----------------|
| script/DeployERC4337Factory.s.sol                | 0.00% (0/8)      | 0.00% (0/12)     | 100.00% (0/0)   | 0.00% (0/2)     |
| src/CoinbaseSmartWallet.sol                      | 100.00% (46/46)  | 100.00% (65/65)  | 100.00% (22/22) | 100.00% (13/13) |
| src/CoinbaseSmartWalletFactory.sol               | 100.00% (10/10)  | 100.00% (10/10)  | 100.00% (4/4)   | 100.00% (4/4)   |
| src/ERC1271.sol                                  | 85.71% (12/14)   | 89.47% (17/19)   | 100.00% (2/2)   | 100.00% (6/6)   |
| src/MultiOwnable.sol                             | 100.00% (27/27)  | 100.00% (38/38)  | 80.00% (8/10)   | 100.00% (13/13) |
| src/utils/ERC1271InputGenerator.sol              | 0.00% (0/9)      | 0.00% (0/14)     | 0.00% (0/6)     | 0.00% (0/1)     |
| test/CoinbaseSmartWallet/SmartWalletTestBase.sol | 0.00% (0/16)     | 0.00% (0/18)     | 0.00% (0/1)     | 0.00% (0/6)     |
| test/CoinbaseSmartWallet/UpgradeToAndCall.t.sol  | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 50.00% (1/2)    |
| test/MultiOwnable/MultiOwnableTestBase.t.sol     | 0.00% (0/3)      | 0.00% (0/3)      | 100.00% (0/0)   | 0.00% (0/1)     |
| test/mocks/MockCoinbaseSmartWallet.sol           | 50.00% (1/2)     | 66.67% (2/3)     | 100.00% (0/0)   | 50.00% (1/2)    |
| test/mocks/MockEntryPoint.sol                    | 40.00% (2/5)     | 33.33% (2/6)     | 0.00% (0/2)     | 33.33% (1/3)    |
| test/mocks/MockMultiOwnable.sol                  | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)   |
| test/mocks/MockTarget.sol                        | 80.00% (4/5)     | 100.00% (4/4)    | 0.00% (0/1)     | 66.67% (2/3)    |
| Total                                            | 70.75% (104/147) | 72.16% (140/194) | 75.00% (36/48)  | 73.68% (42/57)  |
```