### PR TITLE
Add coveralls github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       
         - name: Prune coverage
           run: |
-            lcov-filter lcov.info 'test/|script/|src/utils/' > lcov-filtered.info
+            lcov --remove ./lcov.info -o ./lcov-filtered.info 'test/*' 'script/*' 'src/utils/*' 
 
         - name: Submit coverage to Coveralls
           uses: coverallsapp/github-action@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,16 @@ jobs:
         run: |
           forge fmt --check
         id: fmt
+      
+      - name: Run coverage
+        run: |
+          forge coverage --report summary --report lcov
+          lcov --remove ./lcov.info -o ./lcov.info.pruned 'test/' 'script/' 'src/utils/' 
+
+      - name: Submit coverage to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info.pruned
+          flag-name: foundry
+          parallel: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  check:
+  forge-test:
     strategy:
       fail-fast: true
 
-    name: Foundry project
+    name: Run Forge Tests 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,24 +41,53 @@ jobs:
           forge fmt --check
         id: fmt
 
-      - name: Install lcov
-        run: |
-          sudo apt-get install lcov
-        id: lcov
+  forge-coverage:
+      strategy:
+        fail-fast: true
 
-      - name: Run coverage
-        run: |
-          forge coverage --report summary --report lcov
-    
-      - name: Prune coverage
-        run: |
-          lcov --remove ./lcov.info -o ./lcov.info.pruned 'test/' 'script/' 'src/utils/' 
-          cp ./lcov.info.pruned ./lcov.info
+      name: Run Forge Coverage
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+          with:
+            submodules: recursive
 
-      - name: Submit coverage to Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info
-          flag-name: foundry
-          parallel: true
+        - name: Install Foundry
+          uses: foundry-rs/foundry-toolchain@v1
+          with:
+            version: nightly
+
+        - name: Install forge dependencies
+          run: forge install
+
+        - name: Install lcov
+          run: |
+            sudo apt-get install lcov
+          id: lcov
+
+        - name: Run coverage
+          run: |
+            forge coverage --report summary --report lcov
+      
+        - name: Prune coverage
+          run: |
+            lcov --remove ./lcov.info -o ./lcov.info.pruned 'test/' 'script/' 'src/utils/' 
+            cp ./lcov.info.pruned ./lcov.info
+
+        - name: Submit coverage to Coveralls
+          uses: coverallsapp/github-action@master
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            path-to-lcov: ./lcov.info
+            flag-name: foundry
+            parallel: true
+
+  finish:
+    needs: forge-coverage
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,16 +36,16 @@ jobs:
           forge test -vvv
         id: test
 
+      - name: Check formatting
+        run: |
+          forge fmt --check
+        id: fmt
+
       - name: Install lcov
         run: |
           sudo apt-get install lcov
         id: lcov
 
-      - name: Check formatting
-        run: |
-          forge fmt --check
-        id: fmt
-      
       - name: Run coverage
         run: |
           forge coverage --report summary --report lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Run coverage
         run: |
           forge coverage --report summary --report lcov
-      
-      -name: Prune coverage
+    
+      - name: Prune coverage
         run: |
           lcov --remove ./lcov.info -o ./lcov.info.pruned 'test/' 'script/' 'src/utils/' 
           cp ./lcov.info.pruned ./lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
           forge test -vvv
         id: test
 
+      - name: Install lcov
+        run: |
+          sudo apt-get install lcov
+        id: lcov
+
       - name: Check formatting
         run: |
           forge fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,14 +71,13 @@ jobs:
       
         - name: Prune coverage
           run: |
-            lcov --remove ./lcov.info -o ./lcov.info.pruned 'test/' 'script/' 'src/utils/' 
-            cp ./lcov.info.pruned ./lcov.info
+            lcov-filter lcov.info 'test/|script/|src/utils/' > lcov-filtered.info
 
         - name: Submit coverage to Coveralls
           uses: coverallsapp/github-action@master
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            path-to-lcov: ./lcov.info
+            path-to-lcov: ./lcov-filtered.info
             flag-name: foundry
             parallel: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,16 @@ jobs:
       - name: Run coverage
         run: |
           forge coverage --report summary --report lcov
+      
+      -name: Prune coverage
+        run: |
           lcov --remove ./lcov.info -o ./lcov.info.pruned 'test/' 'script/' 'src/utils/' 
+          cp ./lcov.info.pruned ./lcov.info
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.info.pruned
+          path-to-lcov: ./lcov.info
           flag-name: foundry
           parallel: true


### PR DESCRIPTION
Added coveralls CI. Current benchmark is 97.938%, not 100% due to foundry coverage reporting bug pointed out in https://github.com/coinbase/smart-wallet/pull/37.

The pass/fail settings can be set in the coveralls dashboard for our repo: 
![Screenshot 2024-03-19 at 5 38 28 PM](https://github.com/coinbase/smart-wallet/assets/84420280/4f4b1792-6081-4813-b379-850eea0632a7)
