### PR TITLE
Explicitly require owner removal matches expected owner at index

### DIFF
--- a/certora/specs/ERC4337Account.spec
+++ b/certora/specs/ERC4337Account.spec
@@ -119,7 +119,7 @@ rule OnlyOwnerOrSelf(env e, method f) filtered {
     // There is no difference between filtering functions and using them as a lhs of implication
     f -> f.selector == sig:addOwnerAddress(address).selector 
         || f.selector == sig:addOwnerPublicKey(bytes32, bytes32).selector
-        || f.selector == sig:removeOwnerAtIndex(uint256).selector 
+        || f.selector == sig:removeOwnerAtIndex(uint256, bytes).selector 
         || f.selector == sig:upgradeToAndCall(address, bytes).selector 
 } {
     bool ownerBefore = e.msg.sender == currentContract || isOwnerAddress(e.msg.sender); // owner can remove themselves

--- a/certora/specs/ERC4337AccountInv.spec
+++ b/certora/specs/ERC4337AccountInv.spec
@@ -41,7 +41,7 @@ invariant notTheSameOwnerAgain(uint256 i, uint256 j)
     && (ownerAtIndex(i).length != 0 <=> isOwnerBytes(ownerAtIndex(i)))
     && (ownerAtIndex(j).length != 0 <=> isOwnerBytes(ownerAtIndex(j)))
     {
-        preserved removeOwnerAtIndex(uint256 index) with (env e2) {
+        preserved removeOwnerAtIndex(uint256 index, bytes owner) with (env e2) {
             require i == index;
             bytes empty;
             require empty.length == 0;

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -50,7 +50,6 @@ contract MultiOwnable {
     error NoOwnerAtIndex(uint256 index);
 
     /// @notice Thrown when `owner` argument does not match owner found at index.
-    ///         the provided owner.
     ///
     /// @param index The index of the owner to be removed.
     /// @param owner Owner to be removed which did not match owner found at index.

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -104,7 +104,7 @@ contract MultiOwnable {
 
     /// @notice Removes an owner from the given `index`.
     ///
-    /// @dev Reverts if the provided owner is not registered at `index`.
+    /// @dev Reverts if the provided owner is not found at `index`.
     ///
     /// @param index The index to remove from.
     /// @param owner_ The owner at the specific index.

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -49,7 +49,7 @@ contract MultiOwnable {
     /// @param index The targeted index for removal.
     error NoOwnerAtIndex(uint256 index);
 
-    /// @notice Thrown when trying to remove an owner, but the owner at the given index does not match 
+    /// @notice Thrown when trying to remove an owner, but the owner at the given index does not match
     ///         the provided owner.
     ///
     /// @param index The targeted index for removal.

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -52,7 +52,7 @@ contract MultiOwnable {
     /// @notice Thrown when `owner` argument does not match owner found at index. 
     ///         the provided owner.
     ///
-    /// @param index The targeted index for removal.
+    /// @param index The index of the owner to be removed
     /// @param owner The owner that was attempted to be removed.
 
     error WrongOwnerAtIndex(uint256 index, bytes owner);

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -49,7 +49,7 @@ contract MultiOwnable {
     /// @param index The targeted index for removal.
     error NoOwnerAtIndex(uint256 index);
 
-    /// @notice Thrown when `owner` argument does not match owner found at index. 
+    /// @notice Thrown when `owner` argument does not match owner found at index.
     ///         the provided owner.
     ///
     /// @param index The index of the owner to be removed.

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -54,7 +54,6 @@ contract MultiOwnable {
     ///
     /// @param index The index of the owner to be removed
     /// @param owner The owner that was attempted to be removed.
-
     error WrongOwnerAtIndex(uint256 index, bytes owner);
 
     /// @notice Thrown when trying to intialize the contracts owners if a provided owner is neither

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -104,13 +104,14 @@ contract MultiOwnable {
 
     /// @notice Removes an owner from the given `index`.
     ///
-    /// @dev Reverts if the owner is not registered at `index`.
+    /// @dev Reverts if the provided owner is not registered at `index`.
     ///
     /// @param index The index to remove from.
+    /// @param _owner The owner at the specific index.
     function removeOwnerAtIndex(uint256 index, bytes calldata _owner) public virtual onlyOwner {
         bytes memory owner = ownerAtIndex(index);
-        if (keccak256(owner) != keccak256(_owner)) revert NoOwnerAtIndex(index);
-        if (owner.length == 0) revert WrongOwnerAtIndex(index, _owner);
+        if (owner.length == 0) revert NoOwnerAtIndex(index);
+        if (keccak256(owner) != keccak256(_owner)) revert WrongOwnerAtIndex(index, _owner);
 
         delete _getMultiOwnableStorage().isOwner[owner];
         delete _getMultiOwnableStorage().ownerAtIndex[index];

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -49,6 +49,14 @@ contract MultiOwnable {
     /// @param index The targeted index for removal.
     error NoOwnerAtIndex(uint256 index);
 
+    /// @notice Thrown when trying to remove an owner, but the owner at the given index does not match 
+    ///         the provided owner.
+    ///
+    /// @param index The targeted index for removal.
+    /// @param owner The owner that was attempted to be removed.
+
+    error WrongOwnerAtIndex(uint256 index, bytes owner);
+
     /// @notice Thrown when trying to intialize the contracts owners if a provided owner is neither
     ///         64 bytes long (for passkey) nor a valid address.
     ///
@@ -99,9 +107,10 @@ contract MultiOwnable {
     /// @dev Reverts if the owner is not registered at `index`.
     ///
     /// @param index The index to remove from.
-    function removeOwnerAtIndex(uint256 index) public virtual onlyOwner {
+    function removeOwnerAtIndex(uint256 index, bytes calldata _owner) public virtual onlyOwner {
         bytes memory owner = ownerAtIndex(index);
-        if (owner.length == 0) revert NoOwnerAtIndex(index);
+        if (keccak256(owner) != keccak256(_owner)) revert NoOwnerAtIndex(index);
+        if (owner.length == 0) revert WrongOwnerAtIndex(index, _owner);
 
         delete _getMultiOwnableStorage().isOwner[owner];
         delete _getMultiOwnableStorage().ownerAtIndex[index];

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -52,8 +52,8 @@ contract MultiOwnable {
     /// @notice Thrown when `owner` argument does not match owner found at index. 
     ///         the provided owner.
     ///
-    /// @param index The index of the owner to be removed
-    /// @param owner The owner that was attempted to be removed.
+    /// @param index The index of the owner to be removed.
+    /// @param owner Owner to be removed which did not match owner found at index.
     error WrongOwnerAtIndex(uint256 index, bytes owner);
 
     /// @notice Thrown when trying to intialize the contracts owners if a provided owner is neither

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -107,11 +107,11 @@ contract MultiOwnable {
     /// @dev Reverts if the provided owner is not registered at `index`.
     ///
     /// @param index The index to remove from.
-    /// @param _owner The owner at the specific index.
-    function removeOwnerAtIndex(uint256 index, bytes calldata _owner) public virtual onlyOwner {
+    /// @param owner_ The owner at the specific index.
+    function removeOwnerAtIndex(uint256 index, bytes calldata owner_) public virtual onlyOwner {
         bytes memory owner = ownerAtIndex(index);
         if (owner.length == 0) revert NoOwnerAtIndex(index);
-        if (keccak256(owner) != keccak256(_owner)) revert WrongOwnerAtIndex(index, _owner);
+        if (keccak256(owner) != keccak256(owner_)) revert WrongOwnerAtIndex(index, owner_);
 
         delete _getMultiOwnableStorage().isOwner[owner];
         delete _getMultiOwnableStorage().ownerAtIndex[index];

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -49,7 +49,7 @@ contract MultiOwnable {
     /// @param index The targeted index for removal.
     error NoOwnerAtIndex(uint256 index);
 
-    /// @notice Thrown when trying to remove an owner, but the owner at the given index does not match
+    /// @notice Thrown when `owner` argument does not match owner found at index. 
     ///         the provided owner.
     ///
     /// @param index The targeted index for removal.

--- a/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
+++ b/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
@@ -25,7 +25,7 @@ contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
     }
 
     function testRevertsIfCalledByNonOwner(address a) public {
-        vm.assume(a != owner1Address);
+        vm.assume(a != owner1Address && a != address(mock));
         vm.startPrank(a);
         vm.expectRevert(MultiOwnable.Unauthorized.selector);
         mock.removeOwnerAtIndex(_index(), abi.encode(a));

--- a/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
+++ b/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
@@ -6,14 +6,14 @@ import "./MultiOwnableTestBase.t.sol";
 contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
     function testRemovesOwner() public {
         vm.prank(owner1Address);
-        _removeOwner(owner2Bytes);
+        mock.removeOwnerAtIndex(_index(), owner2Bytes);
         assertFalse(mock.isOwnerBytes(owner2Bytes));
     }
 
     function testRemovesOwnerAtIndex() public {
         uint8 index = _index();
         vm.prank(owner1Address);
-        _removeOwner(owner2Bytes);
+        mock.removeOwnerAtIndex(index, owner2Bytes);
         assertEq(mock.ownerAtIndex(index), hex"");
     }
 
@@ -21,14 +21,14 @@ contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
         vm.expectEmit(true, true, true, true);
         emit MultiOwnable.RemoveOwner(_index(), owner2Bytes);
         vm.prank(owner1Address);
-        _removeOwner(owner2Bytes);
+        mock.removeOwnerAtIndex(_index(), owner2Bytes);
     }
 
     function testRevertsIfCalledByNonOwner(address a) public {
         vm.assume(a != owner1Address);
         vm.startPrank(a);
         vm.expectRevert(MultiOwnable.Unauthorized.selector);
-        _removeOwner(abi.encode(a));
+        mock.removeOwnerAtIndex(_index(), abi.encode(a));
     }
 
     function testRevertsIfNoOwnerAtIndex() public {
@@ -43,10 +43,6 @@ contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
         vm.expectRevert(abi.encodeWithSelector(MultiOwnable.WrongOwnerAtIndex.selector, index, owner1Bytes));
         vm.prank(owner1Address);
         mock.removeOwnerAtIndex(index, owner1Bytes);
-    }
-
-    function _removeOwner(bytes memory owner) internal virtual {
-        mock.removeOwnerAtIndex(_index(), owner);
     }
 
     function _index() internal virtual returns (uint8) {

--- a/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
+++ b/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
@@ -24,10 +24,11 @@ contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
         _removeOwner(owner2Bytes);
     }
 
-    function testRevertsIfCalledByNonOwner() public {
-        vm.startPrank(address(0xdead));
+    function testRevertsIfCalledByNonOwner(address a) public {
+        vm.assume(a != owner1Address);
+        vm.startPrank(a);
         vm.expectRevert(MultiOwnable.Unauthorized.selector);
-        _removeOwner(abi.encode(0xdead));
+        _removeOwner(abi.encode(a));
     }
 
     function testRevertsIfNoOwnerAtIndex() public {

--- a/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
+++ b/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
@@ -6,14 +6,14 @@ import "./MultiOwnableTestBase.t.sol";
 contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
     function testRemovesOwner() public {
         vm.prank(owner1Address);
-        _removeOwner();
+        _removeOwner(owner2Bytes);
         assertFalse(mock.isOwnerBytes(owner2Bytes));
     }
 
     function testRemovesOwnerAtIndex() public {
         uint8 index = _index();
         vm.prank(owner1Address);
-        _removeOwner();
+        _removeOwner(owner2Bytes);
         assertEq(mock.ownerAtIndex(index), hex"");
     }
 
@@ -21,24 +21,31 @@ contract RemoveOwnerAtIndexTest is MultiOwnableTestBase {
         vm.expectEmit(true, true, true, true);
         emit MultiOwnable.RemoveOwner(_index(), owner2Bytes);
         vm.prank(owner1Address);
-        _removeOwner();
+        _removeOwner(owner2Bytes);
     }
 
     function testRevertsIfCalledByNonOwner() public {
         vm.startPrank(address(0xdead));
         vm.expectRevert(MultiOwnable.Unauthorized.selector);
-        _removeOwner();
+        _removeOwner(abi.encode(0xdead));
     }
 
     function testRevertsIfNoOwnerAtIndex() public {
         uint8 index = 10;
         vm.expectRevert(abi.encodeWithSelector(MultiOwnable.NoOwnerAtIndex.selector, index));
         vm.prank(owner1Address);
-        mock.removeOwnerAtIndex(index);
+        mock.removeOwnerAtIndex(index, owner1Bytes);
     }
 
-    function _removeOwner() internal virtual {
-        mock.removeOwnerAtIndex(_index());
+    function testRevertsIfWrongOwnerAtIndex() public {
+        uint8 index = _index();
+        vm.expectRevert(abi.encodeWithSelector(MultiOwnable.WrongOwnerAtIndex.selector, index, owner1Bytes));
+        vm.prank(owner1Address);
+        mock.removeOwnerAtIndex(index, owner1Bytes);
+    }
+
+    function _removeOwner(bytes memory owner) internal virtual {
+        mock.removeOwnerAtIndex(_index(), owner);
     }
 
     function _index() internal virtual returns (uint8) {


### PR DESCRIPTION
An auditor from our Code4rena audit correctly identified that a call to `removeOwnerAtIndex` could be replayed on another chain but might remove a different owner if the owner indexes don't match cross-chain. Since this method is one of the one's that is allowed to be cross-chain repayable, this could lead to a malicious actor removing an owner that shouldn't be removed. 

This PR adds the owner bytes to the `removeOwnerAtIndex` call so that the removal explicitly targets an index _and_ an owner. 