### PR TITLE
Change implementation owner to address(1) from address(0)

### DIFF
--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -102,7 +102,7 @@ contract CoinbaseSmartWallet is MultiOwnable, UUPSUpgradeable, Receiver, ERC1271
     constructor() {
         // Implementation should not be initializable (does not affect proxies which use their own storage).
         bytes[] memory owners = new bytes[](1);
-        owners[0] = abi.encode(address(0));
+        owners[0] = abi.encode(address(1));
         _initializeOwners(owners);
     }
 

--- a/test/ERC1271.t.sol
+++ b/test/ERC1271.t.sol
@@ -15,8 +15,8 @@ contract ERC1271Test is Test {
 
     function setUp() public {
         factory = new CoinbaseSmartWalletFactory(address(new CoinbaseSmartWallet()));
-        owners.push(abi.encode(address(1)));
         owners.push(abi.encode(address(2)));
+        owners.push(abi.encode(address(3)));
         account = factory.createAccount(owners, 0);
     }
 


### PR DESCRIPTION
[This Code4rena finding](https://github.com/code-423n4/2024-03-coinbase-findings/issues/117) correctly points out that the implementation being owned by `address(0)` might expose attack surface area. Though we cannot find a way to exploit this currently, it's trivial to change the implementations owner to `address(1)` to completely eliminate this vector.  