### PR TITLE
rename a variable name to fix a Rust binding issue

### DIFF
--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -234,10 +234,10 @@ contract CoinbaseSmartWallet is MultiOwnable, UUPSUpgradeable, Receiver, ERC1271
 
     /// @notice Returns the implementation of the ERC1967 proxy.
     ///
-    /// @return $ The address of implementation contract.
-    function implementation() public view returns (address $) {
+    /// @return addr The address of implementation contract.
+    function implementation() public view returns (address addr) {
         assembly {
-            $ := sload(_ERC1967_IMPLEMENTATION_SLOT)
+            addr := sload(_ERC1967_IMPLEMENTATION_SLOT)
         }
     }
 


### PR DESCRIPTION
The `$` will be named as `_` when creating Rust bindings, which is a reserved identifier. Rename it to `addr` to fix it.

binding code generated by `forge bind` that doesn't compile:
```rust
  pub struct ImplementationReturn {
      pub _: ::ethers::core::types::Address,
  }
```