### PR TITLE
Add `removeLastOwner` for replayability

### DIFF
--- a/certora/specs/ERC4337Account.spec
+++ b/certora/specs/ERC4337Account.spec
@@ -120,7 +120,7 @@ rule OnlyOwnerOrSelf(env e, method f) filtered {
     f -> f.selector == sig:addOwnerAddress(address).selector 
         || f.selector == sig:addOwnerPublicKey(bytes32, bytes32).selector
         || f.selector == sig:removeOwnerAtIndex(uint256, bytes).selector
-        || f.selector == sig:removeLastOwner(address, bytes).selector
+        || f.selector == sig:removeLastOwner(uint256, bytes).selector
         || f.selector == sig:upgradeToAndCall(address, bytes).selector 
 } {
     bool ownerBefore = e.msg.sender == currentContract || isOwnerAddress(e.msg.sender); // owner can remove themselves

--- a/certora/specs/ERC4337Account.spec
+++ b/certora/specs/ERC4337Account.spec
@@ -119,7 +119,8 @@ rule OnlyOwnerOrSelf(env e, method f) filtered {
     // There is no difference between filtering functions and using them as a lhs of implication
     f -> f.selector == sig:addOwnerAddress(address).selector 
         || f.selector == sig:addOwnerPublicKey(bytes32, bytes32).selector
-        || f.selector == sig:removeOwnerAtIndex(uint256, bytes).selector 
+        || f.selector == sig:removeOwnerAtIndex(uint256, bytes).selector
+        || f.selector == sig:removeLastOwner(address, bytes).selector
         || f.selector == sig:upgradeToAndCall(address, bytes).selector 
 } {
     bool ownerBefore = e.msg.sender == currentContract || isOwnerAddress(e.msg.sender); // owner can remove themselves

--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -255,6 +255,7 @@ contract CoinbaseSmartWallet is MultiOwnable, UUPSUpgradeable, Receiver, ERC1271
             functionSelector == MultiOwnable.addOwnerPublicKey.selector
                 || functionSelector == MultiOwnable.addOwnerAddress.selector
                 || functionSelector == MultiOwnable.removeOwnerAtIndex.selector
+                || functionSelector == MultiOwnable.removeLastOwner.selector
                 || functionSelector == UUPSUpgradeable.upgradeToAndCall.selector
         ) {
             return true;

--- a/test/CoinbaseSmartWallet/CanSkipChainIdValidation.t.sol
+++ b/test/CoinbaseSmartWallet/CanSkipChainIdValidation.t.sol
@@ -8,6 +8,7 @@ contract TestCanSkipChainIdValidation is SmartWalletTestBase {
         MultiOwnable.addOwnerAddress.selector,
         MultiOwnable.addOwnerPublicKey.selector,
         MultiOwnable.removeOwnerAtIndex.selector,
+        MultiOwnable.removeLastOwner.selector,
         UUPSUpgradeable.upgradeToAndCall.selector
     ];
     bytes4[] otherSelectors = [CoinbaseSmartWallet.execute.selector, CoinbaseSmartWallet.executeBatch.selector];


### PR DESCRIPTION
Remediates https://github.com/code-423n4/2024-04-coinbase-mitigation-findings/issues/9

In our code4rena audit, a reviewer correctly identified that we should make `removeLastOwner` a valid replayable transaction. This PR adds that functionality. 