### PR TITLE
fix(ERC1271InputGenerator): fix code start with `0xef` error by adding `0xff` as first byte

### DIFF
--- a/test/ERC1271InputGenerator.t.sol
+++ b/test/ERC1271InputGenerator.t.sol
@@ -25,7 +25,7 @@ contract CoinbaseSmartWallet1271InputGeneratorTest is Test {
         bytes32 hash = 0x15fa6f8c855db1dccbb8a42eef3a7b83f11d29758e84aed37312527165d5eec5;
         bytes32 replaySafeHash = deployedAccount.replaySafeHash(hash);
         ERC1271InputGenerator generator = new ERC1271InputGenerator(deployedAccount, hash, address(0), "");
-        assertEq(bytes32(address(generator).code), replaySafeHash);
+        assertEq(_bytes32FromByteCode(address(generator).code), replaySafeHash);
     }
 
     function testGetReplaySafeHashForUndeployedAccount() public {
@@ -42,6 +42,13 @@ contract CoinbaseSmartWallet1271InputGeneratorTest is Test {
         // This is now deployed.
         bytes32 replaySafeHash = undeployedAccount.replaySafeHash(hash);
 
-        assertEq(bytes32(address(generator).code), replaySafeHash);
+        assertEq(_bytes32FromByteCode(address(generator).code), replaySafeHash);
+    }
+
+    function _bytes32FromByteCode(bytes memory bytecode) private pure returns (bytes32) {
+        bytes32 a = abi.decode(bytecode, (bytes32));
+        uint8 b = uint8(bytecode[bytecode.length - 1]);
+
+        return (a << 8) | bytes32(uint256(b));
     }
 }


### PR DESCRIPTION
It is possible that the computed `replaySafeHash` begins with `0xef`. In such a case, our implementation, inspired by [this example](https://github.com/AmbireTech/signature-validator/blob/d5f84f5fc00bfdf79b80205b983a8258b6d1b3ea/contracts/DeploylessUniversalSigValidator.sol), would result in a contract bytecode also starting with `0xef`.

With the [London](https://github.com/ethereum/go-ethereum/blob/master/params/config.go#L55) upgrade, `create` and `create2` calls [will fail](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L518) if the deployed bytecode begins with `0xef`.

This PR updates the constructor of the `ERC1271InputGenerator` contract to prefix the returned `replaySafeHash` with a constant `0xff` byte. This prevents the aforementioned error from occurring.