### PR TITLE
Correct project typos

### DIFF
--- a/certora/specs/ERC4337Account.spec
+++ b/certora/specs/ERC4337Account.spec
@@ -34,7 +34,7 @@ function isValidSignatureNowCVL(uint256 time, address signer, bytes32 hash, byte
 
 
 // STATUS - verified
-// After initialise has been called, nextOwnerIndex > 0
+// After initialize has been called, nextOwnerIndex > 0
 rule afterInitialize(env e) {
     bytes[] owners;
 
@@ -228,7 +228,7 @@ rule ethBalanceDecreaseByMissingAccountFunds(env e){
     
     uint256 ethBalance_ = nativeBalances[currentContract];
 
-    assert ethBalance_ + missingAccountFunds <= to_mathint(_ethBalance),"eth balance of account should go down by atleast missingAccountFunds";
+    assert ethBalance_ + missingAccountFunds <= to_mathint(_ethBalance),"eth balance of account should go down by at least missingAccountFunds";
 }
 
 
@@ -244,7 +244,7 @@ rule addNewOwnerCheck(env e, method f) filtered {
     bytes ownerAtIndexAnotherBefore = ownerAtIndex(anotherIndex);
     uint256 nextOwnerIndexBefore = nextOwnerIndex();
 
-    require index != anotherIndex;                              // make sure indexes are different to check taht only the latest one was changed
+    require index != anotherIndex;                              // make sure indexes are different to check that only the latest one was changed
     require anotherIndex < nextOwnerIndex();                    // make sure anotherIndex exists, so it should be unchanged
     require isOwnerBytes(ownerAtIndex(anotherIndex));           // set a correlation between ownerAtIndex and isOwnerBytes 
     require index == nextOwnerIndex();                          // checking "only the latest index was changed"                

--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -178,7 +178,7 @@ contract CoinbaseSmartWallet is ERC1271, IAccount, MultiOwnable, UUPSUpgradeable
     /// @notice Executes `calls` on this account (i.e. self call).
     ///
     /// @dev Can only be called by the Entrypoint.
-    /// @dev Reverts if the given call is not authorized to skip the chain ID validtion.
+    /// @dev Reverts if the given call is not authorized to skip the chain ID validation.
     /// @dev `validateUserOp()` will recompute the `userOpHash` without the chain ID before validating
     ///      it if the `UserOperation.calldata` is calling this function. This allows certain UserOperations
     ///      to be replayed for all accounts sharing the same address across chains. E.g. This may be

--- a/src/ERC1271.sol
+++ b/src/ERC1271.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.4;
 /// @notice Abstract ERC-1271 implementation (based on Solady's) with guards to handle the same
 ///         signer being used on multiple accounts.
 ///
-/// @dev To prevent the same signature from being validated on different accounts owned by the samer signer,
+/// @dev To prevent the same signature from being validated on different accounts owned by the same signer,
 ///      we introduce an anti cross-account-replay layer: the original hash is input into a new EIP-712 compliant
 ///      hash. The domain separator of this outer hash contains the chain id and address of this contract, so that
 ///      it cannot be used on two accounts (see `replaySafeHash()` for the implementation details).
@@ -75,7 +75,7 @@ abstract contract ERC1271 {
         return 0xffffffff;
     }
 
-    /// @notice Wrapper around `_eip712Hash()` to produce a replay-safe hash fron the given `hash`.
+    /// @notice Wrapper around `_eip712Hash()` to produce a replay-safe hash from the given `hash`.
     ///
     /// @dev The returned EIP-712 compliant replay-safe hash is the result of:
     ///      keccak256(

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -9,7 +9,7 @@ struct MultiOwnableStorage {
     uint256 nextOwnerIndex;
     /// @dev Tracks number of owners that have been removed.
     uint256 removedOwnersCount;
-    /// @dev Maps index to owner bytes, used to idenfitied owners via a uint256 index.
+    /// @dev Maps index to owner bytes, used to identified owners via a uint256 index.
     ///
     ///      Some uses—-such as signature validation for secp256r1 public key owners—-
     ///      requires the caller to assert the public key of the caller. To economize calldata,

--- a/test/CoinbaseSmartWallet/IsValidSignature.t.sol
+++ b/test/CoinbaseSmartWallet/IsValidSignature.t.sol
@@ -178,7 +178,7 @@ contract TestIsValidSignature is SmartWalletTestBase {
         bytes memory signature = abi.encodePacked(r, s, v);
         bytes32 invalidAddress = bytes32(uint256(type(uint160).max) + 1);
         bytes32 slot_ownerAtIndex =
-            bytes32(uint256(0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f00) + 2); // MUTLI_OWNABLE_STORAGE_LOCATION
+            bytes32(uint256(0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f00) + 2); // MULTI_OWNABLE_STORAGE_LOCATION
             // + 2
         bytes32 slot_ownerAtIndex_zeroIndex =
             bytes32(uint256(keccak256(abi.encodePacked(keccak256(abi.encode(0, slot_ownerAtIndex))))));

--- a/test/CoinbaseSmartWalletFactory.t.sol
+++ b/test/CoinbaseSmartWalletFactory.t.sol
@@ -78,8 +78,8 @@ contract CoinbaseSmartWalletFactoryTest is Test {
     }
 
     function test_initCodeHash() public {
-        bytes32 execptedHash = LibClone.initCodeHashERC1967(address(account));
+        bytes32 executedHash = LibClone.initCodeHashERC1967(address(account));
         bytes32 factoryHash = factory.initCodeHash();
-        assertEq(factoryHash, execptedHash);
+        assertEq(factoryHash, executedHash);
     }
 }

--- a/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
+++ b/test/MultiOwnable/RemoveOwnerAtIndex.t.sol
@@ -8,14 +8,14 @@ contract RemoveOwnerAtIndexTest is RemoveOwnerBaseTest {
         // note this could be fuzzed but it takes a very long time to complete
         uint256 owners = 100;
         MockMultiOwnable mock = new MockMultiOwnable();
-        address firstOnwer = makeAddr("first");
+        address firstOwner = makeAddr("first");
         bytes[] memory initialOwners = new bytes[](1);
-        initialOwners[0] = abi.encode(firstOnwer);
+        initialOwners[0] = abi.encode(firstOwner);
         mock.init(initialOwners);
         assertEq(mock.nextOwnerIndex(), 1);
         assertEq(mock.removedOwnersCount(), 0);
         assertEq(mock.ownerCount(), 1);
-        vm.startPrank(firstOnwer);
+        vm.startPrank(firstOwner);
         for (uint256 i; i < owners; i++) {
             mock.addOwnerAddress(makeAddr(string(abi.encodePacked(i))));
             assertEq(mock.nextOwnerIndex(), i + 2);
@@ -27,6 +27,6 @@ contract RemoveOwnerAtIndexTest is RemoveOwnerBaseTest {
             assertEq(mock.ownerCount(), owners - i + 1);
         }
         vm.expectRevert(MultiOwnable.LastOwner.selector);
-        mock.removeOwnerAtIndex(0, abi.encode(firstOnwer));
+        mock.removeOwnerAtIndex(0, abi.encode(firstOwner));
     }
 }


### PR DESCRIPTION
After analyzing the project code, typos in comments and names of some variables in the contracts have been found and corrected.