### PR TITLE
Use ContractScan for the deployment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Today, allowed are
 Factory and implementation are deployed via [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory), which today will give the same address across 248 chains. See "Deploying" below for instructions on how to deploy to new chains. 
 | Version   | Factory Address                        |
 |-----------|-----------------------------------------|
-| 1 | [0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a](https://basescan.org/address/0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a) |
+| 1 | [0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a](https://contractscan.xyz/contract/0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a) |
 
 
 ## Developing 


### PR DESCRIPTION
Links to [ContractScan](https://contractscan.xyz) which shows the list of all/most deployments of the account factory.

> Disclaimer: I am the author of the tool