### PR TITLE
prototype external storage contract

### DIFF
--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -105,7 +105,7 @@ contract CoinbaseSmartWallet is ERC1271, IAccount, MultiOwnable, UUPSUpgradeable
         }
     }
 
-    constructor() {
+    constructor(address storageContract, bytes32 expectedCodeHash) MultiOwnable(storageContract, expectedCodeHash) {
         // Implementation should not be initializable (does not affect proxies which use their own storage).
         bytes[] memory owners = new bytes[](1);
         owners[0] = abi.encode(address(0));

--- a/src/ExternalWalletStorage.sol
+++ b/src/ExternalWalletStorage.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+/// @title External Wallet Storage
+/// @notice Singleton contract for storing wallet state, protected by caller address and code hash
+contract ExternalWalletStorage {
+    /// @notice Storage layout used by each wallet instance
+    struct WalletStorage {
+        uint256 nextOwnerIndex;
+        uint256 removedOwnersCount;
+        mapping(uint256 index => bytes owner) ownerAtIndex;
+        mapping(bytes bytes_ => bool isOwner_) isOwner;
+    }
+
+    /// @notice Maps (wallet address, wallet code hash) to wallet storage
+    mapping(address => mapping(bytes32 => WalletStorage)) private walletStorage;
+
+    /// @notice Access denied - caller must have expected code hash
+    error UnauthorizedAccess();
+
+    /// @dev Validates caller has expected code hash
+    function _validateCaller(bytes32 expectedCodeHash) internal view {
+        bytes32 callerCodeHash;
+        assembly {
+            callerCodeHash := extcodehash(caller())
+        }
+
+        if (callerCodeHash != expectedCodeHash) {
+            revert UnauthorizedAccess();
+        }
+    }
+
+    /// @notice Gets the next owner index
+    function getNextOwnerIndex(bytes32 expectedCodeHash) external view returns (uint256) {
+        _validateCaller(expectedCodeHash);
+        return walletStorage[msg.sender][expectedCodeHash].nextOwnerIndex;
+    }
+
+    /// @notice Gets the removed owners count
+    function getRemovedOwnersCount(bytes32 expectedCodeHash) external view returns (uint256) {
+        _validateCaller(expectedCodeHash);
+        return walletStorage[msg.sender][expectedCodeHash].removedOwnersCount;
+    }
+
+    /// @notice Gets owner at index
+    function getOwnerAtIndex(bytes32 expectedCodeHash, uint256 index) external view returns (bytes memory) {
+        _validateCaller(expectedCodeHash);
+        return walletStorage[msg.sender][expectedCodeHash].ownerAtIndex[index];
+    }
+
+    /// @notice Checks if bytes is an owner
+    function isOwner(bytes32 expectedCodeHash, bytes calldata ownerBytes) external view returns (bool) {
+        _validateCaller(expectedCodeHash);
+        return walletStorage[msg.sender][expectedCodeHash].isOwner[ownerBytes];
+    }
+
+    /// @notice Sets the next owner index
+    function setNextOwnerIndex(bytes32 expectedCodeHash, uint256 value) external {
+        _validateCaller(expectedCodeHash);
+        walletStorage[msg.sender][expectedCodeHash].nextOwnerIndex = value;
+    }
+
+    /// @notice Sets the removed owners count
+    function setRemovedOwnersCount(bytes32 expectedCodeHash, uint256 value) external {
+        _validateCaller(expectedCodeHash);
+        walletStorage[msg.sender][expectedCodeHash].removedOwnersCount = value;
+    }
+
+    /// @notice Sets owner at index
+    function setOwnerAtIndex(bytes32 expectedCodeHash, uint256 index, bytes calldata owner) external {
+        _validateCaller(expectedCodeHash);
+        walletStorage[msg.sender][expectedCodeHash].ownerAtIndex[index] = owner;
+    }
+
+    /// @notice Sets isOwner flag
+    function setIsOwner(bytes32 expectedCodeHash, bytes calldata ownerBytes, bool value) external {
+        _validateCaller(expectedCodeHash);
+        walletStorage[msg.sender][expectedCodeHash].isOwner[ownerBytes] = value;
+    }
+}


### PR DESCRIPTION
**TL;DR:** Implemented an external storage pattern for the Coinbase Smart Wallet to better handle EIP-7702 delegate transitions. The solution uses a singleton storage contract that namespaces wallet state by both the wallet's address AND its code hash (EXTCODEHASH). This ensures:
- Only the intended delegate implementation can access its storage
- Storage remains isolated even if the EOA switches between different delegates
- Storage access is protected by EXTCODEHASH validation, preventing unauthorized access from other delegates operating at the same address
- While proxy upgrades would require storage migration (due to EXTCODEHASH changes), this tradeoff provides stronger guarantees against storage corruption during delegate transitions

The key innovation is using EXTCODEHASH validation to ensure storage can only be accessed by the specific implementation we expect, rather than relying solely on address-based access control or traditional storage namespacing.

Longer discussion from slack:
"Currently, developers are responsible for preventing storage slot collisions when upgrading EOAs to smart accounts. While Storage Namespace solutions can reduce the likelihood of such conflicts, they do not fully eliminate the risk of EOA storage being overwritten."

I keep thinking that it could be interesting to basically use a separate contract to store wallet state (for example, in the case of CBSW, we're just talking about ownership state). The only issue is that access to read/write on this separate storage contract would presumably need to be gated by something like msg.sender == address(this) , or some other EOA-based signature or auth scheme, which isn't really any more robust against meddling from foreign delegates since they also operate as address(this). Perhaps slightly more robust than namespaced storage which is more likely to be interacted with inadvertently, but still lacks true guarantees.

Another possible idea would be to gate access to the separate storage based on `msg.sender == address(this)` AND `msg.sender.EXTCODEHASH == our_expected_eip7702proxy_address_hash` . This would at least guarantee that only OUR delegate is able to access storage at this separate storage contract. The issue with that would be that upgrading the proxy (which would lead to a different `EXTCODEHASH`) would essentially require re-establishing or migrating ownership from the original system's state to a completely blank storage slate. That said, perhaps upgrading the proxy is an unlikely enough situation (after all, natively deployed smart wallets can't upgrade their proxy) that this blank-slate migration/re-initialization of some sort would be considered acceptable.