### PR TITLE
Owner associated with an owner index outside of the expected bounds should be considered invalid

### DIFF
--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -317,6 +317,12 @@ contract CoinbaseSmartWallet is ERC1271, IAccount, MultiOwnable, UUPSUpgradeable
     /// @param signature ABI encoded `SignatureWrapper`.
     function _isValidSignature(bytes32 hash, bytes calldata signature) internal view virtual override returns (bool) {
         SignatureWrapper memory sigWrapper = abi.decode(signature, (SignatureWrapper));
+        
+        // Ensure owner index is within the valid range
+        if (sigWrapper.ownerIndex >= nextOwnerIndex()) {
+            return false;
+        }
+        
         bytes memory ownerBytes = ownerAtIndex(sigWrapper.ownerIndex);
 
         if (ownerBytes.length == 32) {


### PR DESCRIPTION
While the current implementation of the smart contract wallet is internally consistent with respect to owner indices, an external change to the storage slots at an address can make it so hidden owners can be added to the owner mapping.

In traditional scw's this is impossible, but in case of this contract being used as the implementation for a 7702-delegated eoa, it's possible in the following scenario:
1. User delegates to a malicious entity that sets storage for a hidden owner (i.e. sets an owner at an index above the nextOwnerIndex - for example index 1234, where nextIndex is 1)
2. User delegates back to an implementation of the base smart contract wallet
Before change: The base smart contract wallet will treat an owner at index 1234 as valid even though nextIndex is 1 and this state should not be possible
After change: The base smart contract wallet will treat an owner at index 1234 as invalid