### PR TITLE
Add warning for safe 7702 upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ Today, allowed are
 - MultiOwnable.removeOwnerAtIndex
 - UUPSUpgradeable.upgradeToAndCall
 
-## EIP-7702 delegation safety (important)
-Do **not** directly delegate to a Coinbase Smart Wallet **implementation** contract via EIP-7702. Delegating directly to an implementation can create a security vulnerability.
+## EIP-7702 warning (important)
 
-Instead:
-- Use the `EIP7702Proxy` pattern: [base/eip-7702-proxy](https://github.com/base/eip-7702-proxy)
-- See Coinbase Developer Platform docs for further guidance and an examples of performing a safe EIP-7702 upgrade: [EIP-7702 FAQs – safe upgrade](https://docs.cdp.coinbase.com/paymaster/need-to-knows/eip-7702-faqs#how-do-i-upgrade-my-wallet-to-7702)
+> [!WARNING]
+> Do **not** directly delegate to a Coinbase Smart Wallet **implementation** contract via EIP-7702. Delegating directly to an implementation can create a security vulnerability.
+>
+> Instead:
+> - Use the `EIP7702Proxy` pattern: [base/eip-7702-proxy](https://github.com/base/eip-7702-proxy)
+> - See Coinbase Developer Platform docs for further guidance and an example of performing a safe EIP-7702 upgrade: [EIP-7702 FAQs – safe upgrade](https://docs.cdp.coinbase.com/paymaster/need-to-knows/eip-7702-faqs#how-do-i-upgrade-my-wallet-to-7702)
 
 ## Deployments
 Factory and implementation are deployed via [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory), which today will give the same address across 248 chains. See "Deploying" below for instructions on how to deploy to new chains. 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,10 @@ Today, allowed are
 - MultiOwnable.removeOwnerAtIndex
 - UUPSUpgradeable.upgradeToAndCall
 
-## EIP-7702 warning (important)
-
 > [!WARNING]
+> ## EIP-7702 delegation safety
 > Do **not** directly delegate to a Coinbase Smart Wallet **implementation** contract via EIP-7702. Delegating directly to an implementation can create a security vulnerability.
->
+> 
 > Instead:
 > - Use the `EIP7702Proxy` pattern: [base/eip-7702-proxy](https://github.com/base/eip-7702-proxy)
 > - See Coinbase Developer Platform docs for further guidance and an example of performing a safe EIP-7702 upgrade: [EIP-7702 FAQs – safe upgrade](https://docs.cdp.coinbase.com/paymaster/need-to-knows/eip-7702-faqs#how-do-i-upgrade-my-wallet-to-7702)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Today, allowed are
 - MultiOwnable.removeOwnerAtIndex
 - UUPSUpgradeable.upgradeToAndCall
 
+## EIP-7702 delegation safety (important)
+Do **not** directly delegate to a Coinbase Smart Wallet **implementation** contract via EIP-7702. Delegating directly to an implementation can create a security vulnerability.
+
+Instead:
+- Use the `EIP7702Proxy` pattern: [base/eip-7702-proxy](https://github.com/base/eip-7702-proxy)
+- See Coinbase Developer Platform docs for further guidance and an examples of performing a safe EIP-7702 upgrade: [EIP-7702 FAQs – safe upgrade](https://docs.cdp.coinbase.com/paymaster/need-to-knows/eip-7702-faqs#how-do-i-upgrade-my-wallet-to-7702)
+
 ## Deployments
 Factory and implementation are deployed via [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory), which today will give the same address across 248 chains. See "Deploying" below for instructions on how to deploy to new chains. 
 | Version   | Factory Address                        |


### PR DESCRIPTION
Proactive documentation to help devs avoid unsafe direct 7702-delegation to CoinbaseSmartWallet implementation.