### PR TITLE
test: add comprehensive edge case and fuzz tests for ERC1271InputGenerator

### DIFF
--- a/src/CoinbaseSmartWallet.sol
+++ b/src/CoinbaseSmartWallet.sol
@@ -199,7 +199,7 @@ contract CoinbaseSmartWallet is ERC1271, IAccount, MultiOwnable, UUPSUpgradeable
     /// @notice Executes `calls` on this account (i.e. self call).
     ///
     /// @dev Can only be called by the Entrypoint.
-    /// @dev Reverts if the given call is not authorized to skip the chain ID validtion.
+    /// @dev Reverts if the given call is not authorized to skip the chain ID validation.
     /// @dev `validateUserOp()` will recompute the `userOpHash` without the chain ID before validating
     ///      it if the `UserOperation.calldata` is calling this function. This allows certain UserOperations
     ///      to be replayed for all accounts sharing the same address across chains. E.g. This may be

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -35,7 +35,7 @@ contract MultiOwnable {
     ///      Computed from
     ///      keccak256(abi.encode(uint256(keccak256("coinbase.storage.MultiOwnable")) - 1)) & ~bytes32(uint256(0xff))
     ///      Follows ERC-7201 (see https://eips.ethereum.org/EIPS/eip-7201).
-    bytes32 private constant MUTLI_OWNABLE_STORAGE_LOCATION =
+    bytes32 private constant MULTI_OWNABLE_STORAGE_LOCATION =
         0x97e2c6aad4ce5d562ebfaa00db6b9e0fb66ea5d8162ed5b243f51a2e03086f00;
 
     /// @notice Thrown when the `msg.sender` is not an owner and is trying to call a privileged function.
@@ -281,7 +281,7 @@ contract MultiOwnable {
     /// @return $ A storage reference to the `MultiOwnableStorage` struct.
     function _getMultiOwnableStorage() internal pure returns (MultiOwnableStorage storage $) {
         assembly ("memory-safe") {
-            $.slot := MUTLI_OWNABLE_STORAGE_LOCATION
+            $.slot := MULTI_OWNABLE_STORAGE_LOCATION
         }
     }
 }

--- a/src/MultiOwnable.sol
+++ b/src/MultiOwnable.sol
@@ -9,7 +9,7 @@ struct MultiOwnableStorage {
     uint256 nextOwnerIndex;
     /// @dev Tracks number of owners that have been removed.
     uint256 removedOwnersCount;
-    /// @dev Maps index to owner bytes, used to idenfitied owners via a uint256 index.
+    /// @dev Maps index to owner bytes, used to identified owners via a uint256 index.
     ///
     ///      Some uses—-such as signature validation for secp256r1 public key owners—-
     ///      requires the caller to assert the public key of the caller. To economize calldata,
@@ -267,7 +267,7 @@ contract MultiOwnable {
 
     /// @notice Checks if the sender is an owner of this contract or the contract itself.
     ///
-    /// @dev Revert if the sender is not an owner fo the contract itself.
+    /// @dev Revert if the sender is not an owner of the contract itself.
     function _checkOwner() internal view virtual {
         if (isOwnerAddress(msg.sender) || (msg.sender == address(this))) {
             return;

--- a/test/ERC1271InputGenerator.t.sol
+++ b/test/ERC1271InputGenerator.t.sol
@@ -44,4 +44,93 @@ contract CoinbaseSmartWallet1271InputGeneratorTest is Test {
 
         assertEq(bytes32(address(generator).code), replaySafeHash);
     }
+
+    /// @notice Test replay safe hash with multiple owners
+    function testGetReplaySafeHashWithMultipleOwners() public {
+        owners.push(abi.encode(address(1)));
+        owners.push(abi.encode(address(2)));
+        owners.push(abi.encode(address(3)));
+        deployedAccount = CoinbaseSmartWallet(payable(factory.createAccount(owners, 0)));
+
+        bytes32 hash = 0x15fa6f8c855db1dccbb8a42eef3a7b83f11d29758e84aed37312527165d5eec5;
+        bytes32 replaySafeHash = deployedAccount.replaySafeHash(hash);
+        ERC1271InputGenerator generator = new ERC1271InputGenerator(deployedAccount, hash, address(0), "");
+        assertEq(bytes32(address(generator).code), replaySafeHash);
+    }
+
+    /// @notice Test with different nonce values
+    function testGetReplaySafeHashWithDifferentNonces() public {
+        owners.push(abi.encode(address(1)));
+        
+        // Create accounts with different nonces
+        CoinbaseSmartWallet account0 = CoinbaseSmartWallet(payable(factory.createAccount(owners, 0)));
+        CoinbaseSmartWallet account1 = CoinbaseSmartWallet(payable(factory.createAccount(owners, 1)));
+        
+        bytes32 hash = 0x15fa6f8c855db1dccbb8a42eef3a7b83f11d29758e84aed37312527165d5eec5;
+        
+        bytes32 replaySafeHash0 = account0.replaySafeHash(hash);
+        bytes32 replaySafeHash1 = account1.replaySafeHash(hash);
+        
+        // Different accounts should produce different replay-safe hashes
+        assertTrue(replaySafeHash0 != replaySafeHash1);
+        
+        ERC1271InputGenerator generator0 = new ERC1271InputGenerator(account0, hash, address(0), "");
+        ERC1271InputGenerator generator1 = new ERC1271InputGenerator(account1, hash, address(0), "");
+        
+        assertEq(bytes32(address(generator0).code), replaySafeHash0);
+        assertEq(bytes32(address(generator1).code), replaySafeHash1);
+    }
+
+    /// @notice Test with zero hash
+    function testGetReplaySafeHashWithZeroHash() public {
+        owners.push(abi.encode(address(1)));
+        deployedAccount = CoinbaseSmartWallet(payable(factory.createAccount(owners, 0)));
+
+        bytes32 hash = bytes32(0);
+        bytes32 replaySafeHash = deployedAccount.replaySafeHash(hash);
+        ERC1271InputGenerator generator = new ERC1271InputGenerator(deployedAccount, hash, address(0), "");
+        assertEq(bytes32(address(generator).code), replaySafeHash);
+    }
+
+    /// @notice Fuzz test for replay safe hash with various hashes
+    function testFuzz_GetReplaySafeHash(bytes32 hash) public {
+        owners.push(abi.encode(address(1)));
+        deployedAccount = CoinbaseSmartWallet(payable(factory.createAccount(owners, 0)));
+
+        bytes32 replaySafeHash = deployedAccount.replaySafeHash(hash);
+        ERC1271InputGenerator generator = new ERC1271InputGenerator(deployedAccount, hash, address(0), "");
+        assertEq(bytes32(address(generator).code), replaySafeHash);
+    }
+
+    /// @notice Fuzz test with various owner addresses for deployed accounts
+    function testFuzz_GetReplaySafeHashForDeployedAccount(address owner, bytes32 hash) public {
+        vm.assume(owner != address(0));
+        owners.push(abi.encode(owner));
+        deployedAccount = CoinbaseSmartWallet(payable(factory.createAccount(owners, 0)));
+
+        bytes32 replaySafeHash = deployedAccount.replaySafeHash(hash);
+        ERC1271InputGenerator generator = new ERC1271InputGenerator(deployedAccount, hash, address(0), "");
+        assertEq(bytes32(address(generator).code), replaySafeHash);
+    }
+
+    /// @notice Test that undeployed account with passkey owner works correctly
+    function testGetReplaySafeHashForUndeployedAccountWithPasskeyOwner() public {
+        // Passkey owner (64 bytes - x and y coordinates)
+        bytes32 x = bytes32(uint256(1));
+        bytes32 y = bytes32(uint256(2));
+        owners.push(abi.encode(x, y));
+        
+        CoinbaseSmartWallet undeployedAccount = CoinbaseSmartWallet(payable(factory.getAddress(owners, 0)));
+        bytes32 hash = 0x15fa6f8c855db1dccbb8a42eef3a7b83f11d29758e84aed37312527165d5eec5;
+        ERC1271InputGenerator generator = new ERC1271InputGenerator(
+            undeployedAccount,
+            hash,
+            address(factory),
+            abi.encodeWithSignature("createAccount(bytes[],uint256)", owners, 0)
+        );
+
+        bytes32 replaySafeHash = undeployedAccount.replaySafeHash(hash);
+        assertEq(bytes32(address(generator).code), replaySafeHash);
+    }
 }
+


### PR DESCRIPTION
## Summary

This PR improves test coverage for the `ERC1271InputGenerator` contract by adding edge case tests and fuzz tests.

## New Test Cases

### Edge Case Tests
- **Multiple owners**: Verifies correct hash generation for accounts with 3+ owners
- **Different nonces**: Confirms different nonces produce unique replay-safe hashes
- **Zero hash**: Tests behavior with `bytes32(0)` as input hash
- **Passkey owner**: Tests undeployed account with secp256r1 public key owner (64 bytes)

### Fuzz Tests
- **`testFuzz_GetReplaySafeHash`**: Fuzz tests replay-safe hash with various random hashes
- **`testFuzz_GetReplaySafeHashForDeployedAccount`**: Fuzz tests with random owner addresses and hashes

## Testing

All tests are designed to run with Foundry:
```bash
forge test --match-contract CoinbaseSmartWallet1271InputGeneratorTest