### PR TITLE
ci: pin Foundry to v1.5.1 to avoid nightly drift

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly    
+          version: v1.5.1    
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Run Forge build
         run: |
@@ -54,7 +54,7 @@ jobs:
         - name: Install Foundry
           uses: foundry-rs/foundry-toolchain@v1
           with:
-            version: nightly
+            version: v1.5.1
 
         - name: Install forge dependencies
           run: forge install

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Factory and implementation are deployed via [Safe Singleton Factory](https://git
 
 
 ## Developing 
+This repo pins a specific Foundry version so builds are byte-reproducible and deterministic deployments land on the canonical factory/implementation addresses. CI installs `v1.5.1` (see `.github/workflows/`); match it locally with:
+```bash
+foundryup --install 1.5.1
+```
+
 After cloning the repo, run the tests using Forge, from [Foundry](https://github.com/foundry-rs/foundry?tab=readme-ov-file)
 ```bash
 forge test


### PR DESCRIPTION
## Why

CI installs Foundry via `foundry-rs/foundry-toolchain@v1` with `version: nightly`, which advances daily. A floating toolchain quietly changes:

- **remappings auto-resolution** and **`evm_version` clamping** (e.g. `prague` → `shanghai` on solc 0.8.23), both of which feed the contract metadata hash and therefore the deterministic CREATE2 deploy address
- **`forge fmt` rules**, which drift between nightlies

This is the same class of non-determinism behind the recent non-canonical deploy-address fix (#171). For a repo whose purpose is redeploying the canonical CBSW v1.0.0 / v1.1.0 addresses on new chains, the toolchain should be frozen.

## What

- Pin all three `foundry-toolchain` installs to `v1.5.1`:
  - `.github/workflows/test.yml` (forge-test + forge-coverage jobs)
  - `.github/workflows/certora.yml` (verify job)
- Document matching the version locally in the README via `foundryup --install 1.5.1`.

## Verification

`v1.5.1` reproduces the canonical addresses exactly (`forge clean && forge build`, `deploy` profile):

- implementation → `0x00000110dCdEdC9581cb5eCB8467282f2926534d` ✅
- factory → `0xBA5ED110eFDBa3D005bfC882d75358ACBbB85842` ✅

## Notes

- No contract/source or submodule changes; `solc` stays pinned at `0.8.23` via `foundry.toml`. This PR only freezes the forge/cast binary CI uses.
- This does **not** turn the existing red checks green (the `forge fmt` whitespace and `solady` submodule-fetch failures are separate pre-existing issues, see #171) — it prevents future toolchain drift.
