### PR TITLE
build: pin Foundry version for make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,12 @@
-deploy :; source .env && export FOUNDRY_PROFILE=deploy && forge script script/DeployFactory.s.sol --rpc-url $${RPC_URL}  --account $${ACCOUNT} --broadcast --verify
+FOUNDRY_VERSION := 1.5.1
+
+.PHONY: deploy check-foundry
+
+check-foundry:
+	@forge --version | grep -q "$(FOUNDRY_VERSION)" || { \
+	  echo "forge $(FOUNDRY_VERSION) required (found: $$(forge --version | head -1))"; \
+	  echo "run: foundryup --install $(FOUNDRY_VERSION) && foundryup --use $(FOUNDRY_VERSION)"; \
+	  exit 1; }
+
+deploy: check-foundry
+	source .env && export FOUNDRY_PROFILE=deploy && forge script script/DeployFactory.s.sol --rpc-url $${RPC_URL} --account $${ACCOUNT} --broadcast --verify


### PR DESCRIPTION
## Why

`foundry.toml` pins `solc` (0.8.23) but not the `forge`/`cast` binary, so `make deploy` runs against whatever Foundry is on the operator's PATH. Because the deployed CREATE2 address depends on forge-level behavior (remappings resolution, `evm_version` clamping, metadata), a drifting local toolchain can produce a non-canonical address — exactly the failure mode from #171, which only surfaced as a cryptic `panic: assertion failed` deep in the deploy script.

Companion to #172, which pins the same version in CI. Together they give matched local + CI toolchains.

## What

Add a `check-foundry` prerequisite to the `deploy` target that fails fast unless the active `forge` matches the pinned `FOUNDRY_VERSION` (`1.5.1`), with an actionable hint:

```
forge 1.5.1 required (found: forge Version: 1.4.0-stable)
run: foundryup --install 1.5.1 && foundryup --use 1.5.1
```

`FOUNDRY_VERSION` is a single variable at the top of the Makefile. The deploy command itself is unchanged.

## Why a guard (not auto-install)

Non-intrusive: it won't silently install toolchains or mutate the operator's global Foundry. It complements — doesn't replace — the `assert(implementation == EXPECTED_IMPLEMENTATION)` in `DeployFactory.s.sol`, which remains the hard correctness backstop. This just turns a cryptic panic into a clear "use v1.5.1" message.

## Verification

- `make check-foundry` passes on forge 1.5.1; fails (non-zero) on a mismatched version with the hint above.
- `make -n deploy` confirms the guard runs before the deploy command; deploy invocation unchanged.
- forge 1.5.1 reproduces the canonical addresses exactly (`0x00000110…` / `0xBA5ED1…`).
